### PR TITLE
Indicate disabled state for navigation buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -57,6 +57,19 @@ button {
 button:hover {
     background-color: #5a9bd8;
 }
+button:disabled {
+    cursor: not-allowed;
+}
+
+#prev-btn:disabled,
+#next-btn:disabled {
+    background-color: #a9a9a9; /* DarkGray */
+}
+
+#prev-btn:disabled:hover,
+#next-btn:disabled:hover {
+    background-color: #a9a9a9;
+}
 
 #prev-btn {
     background-color: #ff7f50; /* Coral */


### PR DESCRIPTION
## Summary
- Style disabled buttons with a not-allowed cursor
- Gray out disabled navigation buttons to clarify they are inactive

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d2fe474c8324888112a843ceb7eb