### PR TITLE
Use objects length for limits and clamp current number

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,12 +5,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const nextBtn = document.getElementById('next-btn');
 
     let currentNumber = 1;
-    const maxNumber = 10;
     const minNumber = 1;
 
     const objects = ['🍎', '🚗', '🍌', '🏠', '⭐️', '🎸', '🐶', '☀️', '🚀', '🎈'];
 
     function updateDisplay() {
+        // Clamp currentNumber in case objects array length changes
+        currentNumber = Math.max(minNumber, Math.min(currentNumber, objects.length));
+
         // Update the number
         numberDisplay.textContent = currentNumber;
 
@@ -26,11 +28,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Update button states
         prevBtn.disabled = currentNumber === minNumber;
-        nextBtn.disabled = currentNumber === maxNumber;
+        nextBtn.disabled = currentNumber === objects.length;
     }
 
     nextBtn.addEventListener('click', () => {
-        if (currentNumber < maxNumber) {
+        if (currentNumber < objects.length) {
             currentNumber++;
             updateDisplay();
         }


### PR DESCRIPTION
## Summary
- Replace hardcoded maxNumber with dynamic objects.length
- Clamp currentNumber within valid range when objects array length changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d56c805c832485833560524bb520