### PR TITLE
Add Jest tests for display logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # improved-spoon
+
+## Testing
+
+Install dependencies and run the test suite:
+
+```
+npm install
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "improved-spoon",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -45,4 +45,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initial display update
     updateDisplay();
+
+    // Expose internals for testing
+    window.app = {
+        get currentNumber() {
+            return currentNumber;
+        },
+        set currentNumber(value) {
+            currentNumber = value;
+        },
+        updateDisplay,
+        numberDisplay,
+        objectsDisplay,
+        prevBtn,
+        nextBtn
+    };
 });

--- a/script.test.js
+++ b/script.test.js
@@ -1,0 +1,46 @@
+const path = require('path');
+
+describe('updateDisplay', () => {
+  function setup() {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div id="number-display"></div>
+      <div id="objects-display"></div>
+      <button id="prev-btn"></button>
+      <button id="next-btn"></button>
+    `;
+    require('./script.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    return window.app;
+  }
+
+  test('renders the correct number of emojis', () => {
+    const app = setup();
+    app.currentNumber = 5;
+    app.updateDisplay();
+    expect(app.numberDisplay.textContent).toBe('5');
+    expect(app.objectsDisplay.children.length).toBe(5);
+  });
+
+  test('Next and Previous buttons disable at boundaries', () => {
+    const app = setup();
+
+    // Initial state
+    expect(app.prevBtn.disabled).toBe(true);
+    expect(app.nextBtn.disabled).toBe(false);
+
+    // Click Next until disabled
+    while (!app.nextBtn.disabled) {
+      app.nextBtn.click();
+    }
+    expect(app.currentNumber).toBe(10);
+    expect(app.nextBtn.disabled).toBe(true);
+
+    // Click Previous until disabled
+    while (!app.prevBtn.disabled) {
+      app.prevBtn.click();
+    }
+    expect(app.currentNumber).toBe(1);
+    expect(app.prevBtn.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- expose display logic through `window.app` for testing
- add Jest test verifying emoji rendering and button disabling
- document how to run the new test suite

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d569a20083249907c791785dd23f