### PR TITLE
Add alphabet learning mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,18 @@
 </head>
 <body>
     <div class="container">
+        <div class="mode-select">
+            <label for="mode-select">Learn:</label>
+            <select id="mode-select">
+                <option value="numbers">Numbers</option>
+                <option value="alphabet">Alphabet</option>
+            </select>
+        </div>
         <div id="number-display" class="number-display">1</div>
         <div id="objects-display" class="objects-display">
             <div class="dot"></div>
         </div>
+        <div id="spelling-display" class="spelling-display"></div>
         <div class="buttons">
             <button id="prev-btn">Previous</button>
             <button id="next-btn">Next</button>

--- a/script.js
+++ b/script.js
@@ -3,46 +3,108 @@ document.addEventListener('DOMContentLoaded', () => {
     const objectsDisplay = document.getElementById('objects-display');
     const prevBtn = document.getElementById('prev-btn');
     const nextBtn = document.getElementById('next-btn');
+    const modeSelect = document.getElementById('mode-select');
+    const spellingDisplay = document.getElementById('spelling-display');
 
     let currentNumber = 1;
+    let currentLetterIndex = 0;
     const minNumber = 1;
+    let mode = 'numbers';
 
-    const objects = ['🍎', '🚗', '🍌', '🏠', '⭐️', '🎸', '🐶', '☀️', '🚀', '🎈'];
+    const numberObjects = ['🍎', '🚗', '🍌', '🏠', '⭐️', '🎸', '🐶', '☀️', '🚀', '🎈'];
+    const alphabet = [
+        { letter: 'A', emoji: '🍎', word: 'Apple' },
+        { letter: 'B', emoji: '🐝', word: 'Bee' },
+        { letter: 'C', emoji: '🐱', word: 'Cat' },
+        { letter: 'D', emoji: '🐶', word: 'Dog' },
+        { letter: 'E', emoji: '🐘', word: 'Elephant' },
+        { letter: 'F', emoji: '🐟', word: 'Fish' },
+        { letter: 'G', emoji: '🍇', word: 'Grapes' },
+        { letter: 'H', emoji: '🏠', word: 'House' },
+        { letter: 'I', emoji: '🍦', word: 'Ice cream' },
+        { letter: 'J', emoji: '🧃', word: 'Juice' },
+        { letter: 'K', emoji: '🔑', word: 'Key' },
+        { letter: 'L', emoji: '🦁', word: 'Lion' },
+        { letter: 'M', emoji: '🐵', word: 'Monkey' },
+        { letter: 'N', emoji: '📓', word: 'Notebook' },
+        { letter: 'O', emoji: '🍊', word: 'Orange' },
+        { letter: 'P', emoji: '🦜', word: 'Parrot' },
+        { letter: 'Q', emoji: '👑', word: 'Queen' },
+        { letter: 'R', emoji: '🐰', word: 'Rabbit' },
+        { letter: 'S', emoji: '☀️', word: 'Sun' },
+        { letter: 'T', emoji: '🐯', word: 'Tiger' },
+        { letter: 'U', emoji: '☂️', word: 'Umbrella' },
+        { letter: 'V', emoji: '🎻', word: 'Violin' },
+        { letter: 'W', emoji: '🐳', word: 'Whale' },
+        { letter: 'X', emoji: '🎶', word: 'Xylophone' },
+        { letter: 'Y', emoji: '🧶', word: 'Yarn' },
+        { letter: 'Z', emoji: '🦓', word: 'Zebra' }
+    ];
 
     function updateDisplay() {
-        // Clamp currentNumber in case objects array length changes
-        currentNumber = Math.max(minNumber, Math.min(currentNumber, objects.length));
+        if (mode === 'numbers') {
+            currentNumber = Math.max(minNumber, Math.min(currentNumber, numberObjects.length));
 
-        // Update the number
-        numberDisplay.textContent = currentNumber;
+            numberDisplay.textContent = currentNumber;
 
-        // Update the objects
-        objectsDisplay.innerHTML = ''; // Clear existing objects
-        const objectEmoji = objects[currentNumber - 1];
-        for (let i = 0; i < currentNumber; i++) {
+            objectsDisplay.innerHTML = '';
+            const objectEmoji = numberObjects[currentNumber - 1];
+            for (let i = 0; i < currentNumber; i++) {
+                const object = document.createElement('div');
+                object.classList.add('object');
+                object.textContent = objectEmoji;
+                objectsDisplay.appendChild(object);
+            }
+
+            spellingDisplay.textContent = '';
+            prevBtn.disabled = currentNumber === minNumber;
+            nextBtn.disabled = currentNumber === numberObjects.length;
+        } else {
+            currentLetterIndex = Math.max(0, Math.min(currentLetterIndex, alphabet.length - 1));
+            const { letter, emoji, word } = alphabet[currentLetterIndex];
+
+            numberDisplay.textContent = letter;
+
+            objectsDisplay.innerHTML = '';
             const object = document.createElement('div');
             object.classList.add('object');
-            object.textContent = objectEmoji;
+            object.textContent = emoji;
             objectsDisplay.appendChild(object);
-        }
 
-        // Update button states
-        prevBtn.disabled = currentNumber === minNumber;
-        nextBtn.disabled = currentNumber === objects.length;
+            spellingDisplay.textContent = word;
+            prevBtn.disabled = currentLetterIndex === 0;
+            nextBtn.disabled = currentLetterIndex === alphabet.length - 1;
+        }
     }
 
     nextBtn.addEventListener('click', () => {
-        if (currentNumber < objects.length) {
+        if (mode === 'numbers' && currentNumber < numberObjects.length) {
             currentNumber++;
+            updateDisplay();
+        } else if (mode === 'alphabet' && currentLetterIndex < alphabet.length - 1) {
+            currentLetterIndex++;
             updateDisplay();
         }
     });
 
     prevBtn.addEventListener('click', () => {
-        if (currentNumber > minNumber) {
+        if (mode === 'numbers' && currentNumber > minNumber) {
             currentNumber--;
             updateDisplay();
+        } else if (mode === 'alphabet' && currentLetterIndex > 0) {
+            currentLetterIndex--;
+            updateDisplay();
         }
+    });
+
+    modeSelect.addEventListener('change', () => {
+        mode = modeSelect.value;
+        if (mode === 'numbers') {
+            currentNumber = 1;
+        } else {
+            currentLetterIndex = 0;
+        }
+        updateDisplay();
     });
 
     // Initial display update
@@ -56,10 +118,24 @@ document.addEventListener('DOMContentLoaded', () => {
         set currentNumber(value) {
             currentNumber = value;
         },
+        get currentLetterIndex() {
+            return currentLetterIndex;
+        },
+        set currentLetterIndex(value) {
+            currentLetterIndex = value;
+        },
+        get mode() {
+            return mode;
+        },
+        set mode(value) {
+            mode = value;
+        },
         updateDisplay,
         numberDisplay,
         objectsDisplay,
         prevBtn,
-        nextBtn
+        nextBtn,
+        modeSelect,
+        spellingDisplay
     };
 });

--- a/script.test.js
+++ b/script.test.js
@@ -3,14 +3,65 @@ const path = require('path');
 describe('updateDisplay', () => {
   function setup() {
     jest.resetModules();
-    document.body.innerHTML = `
-      <div id="number-display"></div>
-      <div id="objects-display"></div>
-      <button id="prev-btn"></button>
-      <button id="next-btn"></button>
-    `;
+    const elements = {};
+
+    class Element {
+      constructor(tag) {
+        this.tagName = tag;
+        this.children = [];
+        this._innerHTML = '';
+        this._textContent = '';
+        this.disabled = false;
+        this.value = '';
+        this.classList = { add: () => {} };
+      }
+      appendChild(child) {
+        this.children.push(child);
+      }
+      set innerHTML(val) {
+        this._innerHTML = val;
+        if (val === '') this.children = [];
+      }
+      get innerHTML() {
+        return this._innerHTML;
+      }
+      set textContent(val) {
+        this._textContent = String(val);
+      }
+      get textContent() {
+        return this._textContent;
+      }
+      addEventListener(type, cb) {
+        this['on' + type] = cb;
+      }
+      dispatchEvent(event) {
+        const handler = this['on' + event.type];
+        if (handler) handler(event);
+      }
+      click() {
+        const handler = this.onclick || this['onclick'];
+        if (handler) handler();
+      }
+    }
+
+    global.document = {
+      getElementById: id => elements[id],
+      createElement: tag => new Element(tag),
+      addEventListener: (type, cb) => { if (type === 'DOMContentLoaded') cb(); },
+      body: { appendChild: () => {} }
+    };
+
+    global.window = {};
+
+    elements['number-display'] = new Element('div');
+    elements['objects-display'] = new Element('div');
+    elements['prev-btn'] = new Element('button');
+    elements['next-btn'] = new Element('button');
+    elements['mode-select'] = new Element('select');
+    elements['mode-select'].value = 'numbers';
+    elements['spelling-display'] = new Element('div');
+
     require('./script.js');
-    document.dispatchEvent(new Event('DOMContentLoaded'));
     return window.app;
   }
 
@@ -41,6 +92,37 @@ describe('updateDisplay', () => {
       app.prevBtn.click();
     }
     expect(app.currentNumber).toBe(1);
+    expect(app.prevBtn.disabled).toBe(true);
+  });
+
+  test('alphabet mode displays letter, emoji and word', () => {
+    const app = setup();
+    app.modeSelect.value = 'alphabet';
+    app.modeSelect.dispatchEvent(new Event('change'));
+    expect(app.numberDisplay.textContent).toBe('A');
+    expect(app.objectsDisplay.children.length).toBe(1);
+    expect(app.spellingDisplay.textContent).toBe('Apple');
+
+    app.nextBtn.click();
+    expect(app.numberDisplay.textContent).toBe('B');
+    expect(app.spellingDisplay.textContent).toBe('Bee');
+  });
+
+  test('alphabet boundaries disable navigation', () => {
+    const app = setup();
+    app.modeSelect.value = 'alphabet';
+    app.modeSelect.dispatchEvent(new Event('change'));
+
+    expect(app.prevBtn.disabled).toBe(true);
+    while (!app.nextBtn.disabled) {
+      app.nextBtn.click();
+    }
+    expect(app.numberDisplay.textContent).toBe('Z');
+    expect(app.nextBtn.disabled).toBe(true);
+    while (!app.prevBtn.disabled) {
+      app.prevBtn.click();
+    }
+    expect(app.numberDisplay.textContent).toBe('A');
     expect(app.prevBtn.disabled).toBe(true);
   });
 });

--- a/style.css
+++ b/style.css
@@ -22,6 +22,10 @@ body {
     margin-bottom: 20px;
 }
 
+.mode-select {
+    margin-bottom: 20px;
+}
+
 .objects-display {
     display: flex;
     flex-wrap: wrap;
@@ -35,6 +39,12 @@ body {
 
 .object {
     font-size: 40px;
+}
+
+.spelling-display {
+    font-size: 32px;
+    color: #4682b4; /* SteelBlue */
+    margin-bottom: 20px;
 }
 
 .buttons {


### PR DESCRIPTION
## Summary
- add mode selector to choose numbers or alphabet learning
- display letters A-Z with emoji objects and spelled words
- test alphabet navigation with minimal DOM stubs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898da8310788324b09458c9734a41b0