### PR TITLE
Add keyboard navigation and flip animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container">
+    <div class="container" id="card">
         <div class="mode-select">
             <label for="mode-select">Learn:</label>
             <select id="mode-select">

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const nextBtn = document.getElementById('next-btn');
     const modeSelect = document.getElementById('mode-select');
     const spellingDisplay = document.getElementById('spelling-display');
+    const card = document.getElementById('card');
 
     let currentNumber = 1;
     let currentLetterIndex = 0;
@@ -110,7 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
             prevBtn.disabled = currentLetterIndex === 0;
             nextBtn.disabled = currentLetterIndex === alphabet.length - 1;
 
-            speak(letter);
+            speak(letter.toLowerCase());
             speakTimeout = setTimeout(() => speak(word), 1000);
         }
 
@@ -143,7 +144,17 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             currentLetterIndex = 0;
         }
+        card.classList.add('flip');
+        setTimeout(() => card.classList.remove('flip'), 600);
         updateDisplay();
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowRight') {
+            nextBtn.click();
+        } else if (e.key === 'ArrowLeft') {
+            prevBtn.click();
+        }
     });
 
     // Initial display update

--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@ body {
     align-items: center;
     height: 100vh;
     margin: 0;
+    perspective: 1000px;
 }
 
 .container {
@@ -14,6 +15,12 @@ body {
     padding: 20px;
     border-radius: 20px;
     box-shadow: 0 10px 20px rgba(0,0,0,0.1);
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+}
+
+.container.flip {
+    transform: rotateY(180deg);
 }
 
 .number-display {


### PR DESCRIPTION
## Summary
- Flip the learning card when switching between numbers and alphabet
- Support left and right arrow keys for navigation
- Speak only the letter name without "capital" prefix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b52f8f508324b1cd4c96c6b103c7