### PR TITLE
Enable persistent card flip for numbers and alphabet modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,22 +7,33 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container" id="card">
-        <div class="mode-select">
-            <label for="mode-select">Learn:</label>
-            <select id="mode-select">
-                <option value="numbers">Numbers</option>
-                <option value="alphabet">Alphabet</option>
-            </select>
+    <div class="mode-select">
+        <label for="mode-select">Learn:</label>
+        <select id="mode-select">
+            <option value="numbers">Numbers</option>
+            <option value="alphabet">Alphabet</option>
+        </select>
+    </div>
+    <div class="card" id="card">
+        <div class="card-face card-front">
+            <div id="number-display" class="number-display">1</div>
+            <div id="objects-display" class="objects-display">
+                <div class="dot"></div>
+            </div>
+            <div id="spelling-display" class="spelling-display"></div>
+            <div class="buttons">
+                <button id="prev-btn">Previous</button>
+                <button id="next-btn">Next</button>
+            </div>
         </div>
-        <div id="number-display" class="number-display">1</div>
-        <div id="objects-display" class="objects-display">
-            <div class="dot"></div>
-        </div>
-        <div id="spelling-display" class="spelling-display"></div>
-        <div class="buttons">
-            <button id="prev-btn">Previous</button>
-            <button id="next-btn">Next</button>
+        <div class="card-face card-back">
+            <div id="letter-display" class="number-display">A</div>
+            <div id="alphabet-objects-display" class="objects-display"></div>
+            <div id="alphabet-spelling-display" class="spelling-display"></div>
+            <div class="buttons">
+                <button id="alphabet-prev-btn">Previous</button>
+                <button id="alphabet-next-btn">Next</button>
+            </div>
         </div>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,11 +1,27 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const numberDisplay = document.getElementById('number-display');
-    const objectsDisplay = document.getElementById('objects-display');
-    const prevBtn = document.getElementById('prev-btn');
-    const nextBtn = document.getElementById('next-btn');
     const modeSelect = document.getElementById('mode-select');
-    const spellingDisplay = document.getElementById('spelling-display');
     const card = document.getElementById('card');
+
+    const numberElements = {
+        display: document.getElementById('number-display'),
+        objects: document.getElementById('objects-display'),
+        spelling: document.getElementById('spelling-display'),
+        prev: document.getElementById('prev-btn'),
+        next: document.getElementById('next-btn')
+    };
+
+    const alphabetElements = {
+        display: document.getElementById('letter-display'),
+        objects: document.getElementById('alphabet-objects-display'),
+        spelling: document.getElementById('alphabet-spelling-display'),
+        prev: document.getElementById('alphabet-prev-btn'),
+        next: document.getElementById('alphabet-next-btn')
+    };
+
+    const elements = {
+        numbers: numberElements,
+        alphabet: alphabetElements
+    };
 
     let currentNumber = 1;
     let currentLetterIndex = 0;
@@ -73,23 +89,25 @@ document.addEventListener('DOMContentLoaded', () => {
             speakTimeout = null;
         }
 
+        const el = elements[mode];
+
         if (mode === 'numbers') {
             currentNumber = Math.max(minNumber, Math.min(currentNumber, numberObjects.length));
 
-            numberDisplay.textContent = currentNumber;
+            el.display.textContent = currentNumber;
 
-            objectsDisplay.innerHTML = '';
+            el.objects.innerHTML = '';
             const { emoji, singular, plural } = numberObjects[currentNumber - 1];
             for (let i = 0; i < currentNumber; i++) {
                 const object = document.createElement('div');
                 object.classList.add('object');
                 object.textContent = emoji;
-                objectsDisplay.appendChild(object);
+                el.objects.appendChild(object);
             }
 
-            spellingDisplay.textContent = '';
-            prevBtn.disabled = currentNumber === minNumber;
-            nextBtn.disabled = currentNumber === numberObjects.length;
+            el.spelling.textContent = '';
+            el.prev.disabled = currentNumber === minNumber;
+            el.next.disabled = currentNumber === numberObjects.length;
 
             speak(currentNumber);
             const word = currentNumber === 1 ? singular : plural;
@@ -98,18 +116,17 @@ document.addEventListener('DOMContentLoaded', () => {
             currentLetterIndex = Math.max(0, Math.min(currentLetterIndex, alphabet.length - 1));
             const { letter, emoji, word } = alphabet[currentLetterIndex];
 
-            numberDisplay.textContent = letter;
+            el.display.textContent = letter;
 
-            objectsDisplay.innerHTML = '';
+            el.objects.innerHTML = '';
             const object = document.createElement('div');
             object.classList.add('object');
             object.textContent = emoji;
-            objectsDisplay.appendChild(object);
+            el.objects.appendChild(object);
 
-
-            spellingDisplay.textContent = word;
-            prevBtn.disabled = currentLetterIndex === 0;
-            nextBtn.disabled = currentLetterIndex === alphabet.length - 1;
+            el.spelling.textContent = word;
+            el.prev.disabled = currentLetterIndex === 0;
+            el.next.disabled = currentLetterIndex === alphabet.length - 1;
 
             speak(letter.toLowerCase());
             speakTimeout = setTimeout(() => speak(word), 1000);
@@ -117,7 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     }
 
-    nextBtn.addEventListener('click', () => {
+    function handleNext() {
         if (mode === 'numbers' && currentNumber < numberObjects.length) {
             currentNumber++;
             updateDisplay();
@@ -125,9 +142,9 @@ document.addEventListener('DOMContentLoaded', () => {
             currentLetterIndex++;
             updateDisplay();
         }
-    });
+    }
 
-    prevBtn.addEventListener('click', () => {
+    function handlePrev() {
         if (mode === 'numbers' && currentNumber > minNumber) {
             currentNumber--;
             updateDisplay();
@@ -135,25 +152,30 @@ document.addEventListener('DOMContentLoaded', () => {
             currentLetterIndex--;
             updateDisplay();
         }
-    });
+    }
+
+    numberElements.next.addEventListener('click', handleNext);
+    alphabetElements.next.addEventListener('click', handleNext);
+    numberElements.prev.addEventListener('click', handlePrev);
+    alphabetElements.prev.addEventListener('click', handlePrev);
 
     modeSelect.addEventListener('change', () => {
         mode = modeSelect.value;
         if (mode === 'numbers') {
             currentNumber = 1;
+            card.classList.remove('flipped');
         } else {
             currentLetterIndex = 0;
+            card.classList.add('flipped');
         }
-        card.classList.add('flip');
-        setTimeout(() => card.classList.remove('flip'), 600);
         updateDisplay();
     });
 
     document.addEventListener('keydown', (e) => {
         if (e.key === 'ArrowRight') {
-            nextBtn.click();
+            handleNext();
         } else if (e.key === 'ArrowLeft') {
-            prevBtn.click();
+            handlePrev();
         }
     });
 
@@ -181,11 +203,21 @@ document.addEventListener('DOMContentLoaded', () => {
             mode = value;
         },
         updateDisplay,
-        numberDisplay,
-        objectsDisplay,
-        prevBtn,
-        nextBtn,
+        get numberDisplay() {
+            return elements[mode].display;
+        },
+        get objectsDisplay() {
+            return elements[mode].objects;
+        },
+        get prevBtn() {
+            return elements[mode].prev;
+        },
+        get nextBtn() {
+            return elements[mode].next;
+        },
         modeSelect,
-        spellingDisplay
+        get spellingDisplay() {
+            return elements[mode].spelling;
+        }
     };
 });

--- a/script.test.js
+++ b/script.test.js
@@ -29,6 +29,11 @@ describe('updateDisplay', () => {
       'mode-select': createMockElement(),
       'spelling-display': createMockElement(),
       'card': createMockElement(),
+      'letter-display': createMockElement(),
+      'alphabet-objects-display': createMockElement(),
+      'alphabet-prev-btn': createMockElement(),
+      'alphabet-next-btn': createMockElement(),
+      'alphabet-spelling-display': createMockElement(),
     };
 
     const document = {

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@ body {
     font-family: 'Arial Rounded MT Bold', 'Helvetica Rounded', Arial, sans-serif;
     background-color: #f0f8ff; /* AliceBlue */
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     height: 100vh;
@@ -9,17 +10,37 @@ body {
     perspective: 1000px;
 }
 
-.container {
+.card {
+    position: relative;
+    width: 360px;
+    height: 480px;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+}
+
+.card.flipped {
+    transform: rotateY(180deg);
+}
+
+.card-face {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    backface-visibility: hidden;
     text-align: center;
     background-color: #ffffff;
     padding: 20px;
     border-radius: 20px;
     box-shadow: 0 10px 20px rgba(0,0,0,0.1);
-    transition: transform 0.6s;
-    transform-style: preserve-3d;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
-.container.flip {
+.card-back {
     transform: rotateY(180deg);
 }
 
@@ -79,19 +100,25 @@ button:disabled {
 }
 
 #prev-btn:disabled,
-#next-btn:disabled {
+#next-btn:disabled,
+#alphabet-prev-btn:disabled,
+#alphabet-next-btn:disabled {
     background-color: #a9a9a9; /* DarkGray */
 }
 
 #prev-btn:disabled:hover,
-#next-btn:disabled:hover {
+#next-btn:disabled:hover,
+#alphabet-prev-btn:disabled:hover,
+#alphabet-next-btn:disabled:hover {
     background-color: #a9a9a9;
 }
 
-#prev-btn {
+#prev-btn,
+#alphabet-prev-btn {
     background-color: #ff7f50; /* Coral */
 }
 
-#prev-btn:hover {
+#prev-btn:hover,
+#alphabet-prev-btn:hover {
     background-color: #ff9f7a;
 }


### PR DESCRIPTION
## Summary
- Create front and back card faces to separate numbers and alphabet activities
- Add 3D flip styling and persistent orientation based on selected mode
- Update logic and tests for dual faces and navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b752c3508324bd3f6bc4bea700ac