### PR TITLE
Add colors learning mode with UI and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <select id="mode-select">
             <option value="numbers">Numbers</option>
             <option value="alphabet">Alphabet</option>
+            <option value="colors">Colors</option>
         </select>
     </div>
     <div class="card" id="card">
@@ -33,6 +34,17 @@
             <div class="buttons">
                 <button id="alphabet-prev-btn">Previous</button>
                 <button id="alphabet-next-btn">Next</button>
+            </div>
+        </div>
+        <div class="card-face card-color">
+            <div id="color-display" class="number-display">Red</div>
+            <div id="color-objects-display" class="objects-display">
+                <div class="dot"></div>
+            </div>
+            <div id="color-spelling-display" class="spelling-display"></div>
+            <div class="buttons">
+                <button id="color-prev-btn">Previous</button>
+                <button id="color-next-btn">Next</button>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
     const modeSelect = document.getElementById('mode-select');
     const card = document.getElementById('card');
+    const cardFront = document.querySelector('.card-front');
+    const cardBack = document.querySelector('.card-back');
+    const cardColor = document.querySelector('.card-color');
 
     const numberElements = {
         display: document.getElementById('number-display'),
@@ -18,13 +21,23 @@ document.addEventListener('DOMContentLoaded', () => {
         next: document.getElementById('alphabet-next-btn')
     };
 
+    const colorElements = {
+        display: document.getElementById('color-display'),
+        objects: document.getElementById('color-objects-display'),
+        spelling: document.getElementById('color-spelling-display'),
+        prev: document.getElementById('color-prev-btn'),
+        next: document.getElementById('color-next-btn')
+    };
+
     const elements = {
         numbers: numberElements,
-        alphabet: alphabetElements
+        alphabet: alphabetElements,
+        colors: colorElements
     };
 
     let currentNumber = 1;
     let currentLetterIndex = 0;
+    let currentColorIndex = 0;
     const minNumber = 1;
     let mode = 'numbers';
 
@@ -67,6 +80,15 @@ document.addEventListener('DOMContentLoaded', () => {
         { letter: 'X', emoji: '🎶', word: 'Xylophone' },
         { letter: 'Y', emoji: '🧶', word: 'Yarn' },
         { letter: 'Z', emoji: '🦓', word: 'Zebra' }
+    ];
+
+    const colors = [
+        { name: 'Red', emoji: '🔴' },
+        { name: 'Blue', emoji: '🔵' },
+        { name: 'Green', emoji: '🟢' },
+        { name: 'Yellow', emoji: '🟡' },
+        { name: 'Purple', emoji: '🟣' },
+        { name: 'Orange', emoji: '🟠' }
     ];
 
     let speakTimeout;
@@ -112,7 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
             speak(currentNumber);
             const word = currentNumber === 1 ? singular : plural;
             speakTimeout = setTimeout(() => speak(`${currentNumber} ${word}`), 1000);
-        } else {
+        } else if (mode === 'alphabet') {
             currentLetterIndex = Math.max(0, Math.min(currentLetterIndex, alphabet.length - 1));
             const { letter, emoji, word } = alphabet[currentLetterIndex];
 
@@ -130,6 +152,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
             speak(letter.toLowerCase());
             speakTimeout = setTimeout(() => speak(word), 1000);
+        } else {
+            currentColorIndex = Math.max(0, Math.min(currentColorIndex, colors.length - 1));
+            const { name, emoji } = colors[currentColorIndex];
+
+            el.display.textContent = name;
+
+            el.objects.innerHTML = '';
+            const object = document.createElement('div');
+            object.classList.add('object');
+            object.textContent = emoji;
+            el.objects.appendChild(object);
+
+            el.spelling.textContent = '';
+            el.prev.disabled = currentColorIndex === 0;
+            el.next.disabled = currentColorIndex === colors.length - 1;
+
+            speak(name);
         }
 
     }
@@ -141,6 +180,9 @@ document.addEventListener('DOMContentLoaded', () => {
         } else if (mode === 'alphabet' && currentLetterIndex < alphabet.length - 1) {
             currentLetterIndex++;
             updateDisplay();
+        } else if (mode === 'colors' && currentColorIndex < colors.length - 1) {
+            currentColorIndex++;
+            updateDisplay();
         }
     }
 
@@ -151,22 +193,39 @@ document.addEventListener('DOMContentLoaded', () => {
         } else if (mode === 'alphabet' && currentLetterIndex > 0) {
             currentLetterIndex--;
             updateDisplay();
+        } else if (mode === 'colors' && currentColorIndex > 0) {
+            currentColorIndex--;
+            updateDisplay();
         }
     }
 
     numberElements.next.addEventListener('click', handleNext);
     alphabetElements.next.addEventListener('click', handleNext);
+    colorElements.next.addEventListener('click', handleNext);
     numberElements.prev.addEventListener('click', handlePrev);
     alphabetElements.prev.addEventListener('click', handlePrev);
+    colorElements.prev.addEventListener('click', handlePrev);
+
+    function showFace(currentMode) {
+        cardFront.style.display = currentMode === 'numbers' ? 'flex' : 'none';
+        cardBack.style.display = currentMode === 'alphabet' ? 'flex' : 'none';
+        cardColor.style.display = currentMode === 'colors' ? 'flex' : 'none';
+    }
 
     modeSelect.addEventListener('change', () => {
         mode = modeSelect.value;
         if (mode === 'numbers') {
             currentNumber = 1;
             card.classList.remove('flipped');
-        } else {
+            showFace('numbers');
+        } else if (mode === 'alphabet') {
             currentLetterIndex = 0;
             card.classList.add('flipped');
+            showFace('alphabet');
+        } else {
+            currentColorIndex = 0;
+            card.classList.remove('flipped');
+            showFace('colors');
         }
         updateDisplay();
     });
@@ -179,6 +238,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    showFace('numbers');
     // Initial display update
     updateDisplay();
 
@@ -195,6 +255,12 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         set currentLetterIndex(value) {
             currentLetterIndex = value;
+        },
+        get currentColorIndex() {
+            return currentColorIndex;
+        },
+        set currentColorIndex(value) {
+            currentColorIndex = value;
         },
         get mode() {
             return mode;

--- a/script.test.js
+++ b/script.test.js
@@ -4,6 +4,7 @@ describe('updateDisplay', () => {
     return {
       children: [],
       classList: { add: jest.fn(), remove: jest.fn() },
+      style: {},
       appendChild(child) { this.children.push(child); },
       set innerHTML(value) { if (value === '') this.children = []; },
       get textContent() { return text; },
@@ -34,11 +35,23 @@ describe('updateDisplay', () => {
       'alphabet-prev-btn': createMockElement(),
       'alphabet-next-btn': createMockElement(),
       'alphabet-spelling-display': createMockElement(),
+      'color-display': createMockElement(),
+      'color-objects-display': createMockElement(),
+      'color-prev-btn': createMockElement(),
+      'color-next-btn': createMockElement(),
+      'color-spelling-display': createMockElement(),
+    };
+
+    const selectors = {
+      '.card-front': createMockElement(),
+      '.card-back': createMockElement(),
+      '.card-color': createMockElement(),
     };
 
     const document = {
       getElementById: id => elements[id],
       createElement: () => createMockElement(),
+      querySelector: sel => selectors[sel],
       _listeners: {},
       addEventListener(event, handler) { this._listeners[event] = handler; },
       dispatchEvent(event) { const h = this._listeners[event.type]; h && h(event); }
@@ -81,6 +94,23 @@ describe('updateDisplay', () => {
     expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(2);
     expect(window.speechSynthesis.speak.mock.calls[0][0].text).toBe('b');
     expect(window.speechSynthesis.speak.mock.calls[1][0].text).toBe('Bee');
+  });
+
+  test('color mode renders and speaks color names', () => {
+    const app = setup();
+    app.modeSelect.value = 'colors';
+    app.modeSelect.dispatchEvent(new Event('change'));
+    expect(app.numberDisplay.textContent).toBe('Red');
+    expect(app.objectsDisplay.children.length).toBe(1);
+    expect(app.objectsDisplay.children[0].textContent).toBe('🔴');
+
+    window.speechSynthesis.speak.mockClear();
+    app.nextBtn.click();
+    jest.runAllTimers();
+    expect(app.numberDisplay.textContent).toBe('Blue');
+    expect(app.objectsDisplay.children[0].textContent).toBe('🔵');
+    expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(1);
+    expect(window.speechSynthesis.speak.mock.calls[0][0].text).toBe('Blue');
   });
 
   test('Next and Previous buttons disable at boundaries', () => {

--- a/style.css
+++ b/style.css
@@ -44,6 +44,10 @@ body {
     transform: rotateY(180deg);
 }
 
+.card-color {
+    display: none;
+}
+
 .number-display {
     font-size: 120px;
     color: #ff6347; /* Tomato */


### PR DESCRIPTION
## Summary
- Extend interface with a new Colors mode and third card face for showing color names and emojis.
- Implement color data set and logic to render, speak, and navigate through colors alongside numbers and alphabet.
- Add styling and unit tests verifying color mode rendering and speech.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899c69ee0208324a3bed066b4390883