### PR TITLE
Improve color learning visuals

### DIFF
--- a/script.js
+++ b/script.js
@@ -83,12 +83,16 @@ document.addEventListener('DOMContentLoaded', () => {
     ];
 
     const colors = [
-        { name: 'Red', emoji: '🔴' },
-        { name: 'Blue', emoji: '🔵' },
-        { name: 'Green', emoji: '🟢' },
-        { name: 'Yellow', emoji: '🟡' },
-        { name: 'Purple', emoji: '🟣' },
-        { name: 'Orange', emoji: '🟠' }
+        { name: 'Red', emoji: '🔴', hex: '#FF0000' },
+        { name: 'Blue', emoji: '🔵', hex: '#0000FF' },
+        { name: 'Green', emoji: '🟢', hex: '#008000' },
+        { name: 'Yellow', emoji: '🟡', hex: '#FFFF00' },
+        { name: 'Purple', emoji: '🟣', hex: '#800080' },
+        { name: 'Orange', emoji: '🟠', hex: '#FFA500' },
+        { name: 'Pink', emoji: '💗', hex: '#FF69B4' },
+        { name: 'Brown', emoji: '🟤', hex: '#A52A2A' },
+        { name: 'Black', emoji: '⚫', hex: '#000000' },
+        { name: 'White', emoji: '⚪', hex: '#FFFFFF' }
     ];
 
     let speakTimeout;
@@ -154,9 +158,10 @@ document.addEventListener('DOMContentLoaded', () => {
             speakTimeout = setTimeout(() => speak(word), 1000);
         } else {
             currentColorIndex = Math.max(0, Math.min(currentColorIndex, colors.length - 1));
-            const { name, emoji } = colors[currentColorIndex];
+            const { name, emoji, hex } = colors[currentColorIndex];
 
             el.display.textContent = name;
+            el.display.style.color = hex;
 
             el.objects.innerHTML = '';
             const object = document.createElement('div');

--- a/script.test.js
+++ b/script.test.js
@@ -8,13 +8,18 @@ describe('updateDisplay', () => {
       appendChild(child) { this.children.push(child); },
       set innerHTML(value) { if (value === '') this.children = []; },
       get textContent() { return text; },
-      set textContent(value) { text = String(value); },
+      set textContent(value) {
+        text = String(value);
+        this.scrollWidth = text.length * 10;
+      },
       disabled: false,
       value: '',
       _listeners: {},
       addEventListener(event, handler) { this._listeners[event] = handler; },
       dispatchEvent(event) { const h = this._listeners[event.type]; h && h(event); },
-      click() { this._listeners.click && this._listeners.click(); }
+      click() { this._listeners.click && this._listeners.click(); },
+      clientWidth: 360,
+      scrollWidth: 0
     };
   }
 
@@ -111,6 +116,36 @@ describe('updateDisplay', () => {
     expect(app.objectsDisplay.children[0].textContent).toBe('🔵');
     expect(window.speechSynthesis.speak).toHaveBeenCalledTimes(1);
     expect(window.speechSynthesis.speak.mock.calls[0][0].text).toBe('Blue');
+  });
+
+  test('all colors display correct data and styling without overflow', () => {
+    const expectedColors = [
+      { name: 'Red', emoji: '🔴', hex: '#FF0000' },
+      { name: 'Blue', emoji: '🔵', hex: '#0000FF' },
+      { name: 'Green', emoji: '🟢', hex: '#008000' },
+      { name: 'Yellow', emoji: '🟡', hex: '#FFFF00' },
+      { name: 'Purple', emoji: '🟣', hex: '#800080' },
+      { name: 'Orange', emoji: '🟠', hex: '#FFA500' },
+      { name: 'Pink', emoji: '💗', hex: '#FF69B4' },
+      { name: 'Brown', emoji: '🟤', hex: '#A52A2A' },
+      { name: 'Black', emoji: '⚫', hex: '#000000' },
+      { name: 'White', emoji: '⚪', hex: '#FFFFFF' }
+    ];
+
+    const app = setup();
+    app.modeSelect.value = 'colors';
+    app.modeSelect.dispatchEvent(new Event('change'));
+
+    expectedColors.forEach((color, index) => {
+      expect(app.numberDisplay.textContent).toBe(color.name);
+      expect(app.numberDisplay.style.color).toBe(color.hex);
+      expect(app.objectsDisplay.children[0].textContent).toBe(color.emoji);
+      expect(app.numberDisplay.scrollWidth).toBeLessThanOrEqual(app.numberDisplay.clientWidth);
+
+      if (index < expectedColors.length - 1) {
+        app.nextBtn.click();
+      }
+    });
   });
 
   test('Next and Previous buttons disable at boundaries', () => {

--- a/style.css
+++ b/style.css
@@ -54,6 +54,13 @@ body {
     margin-bottom: 20px;
 }
 
+/* Adjust color word size and prevent overflow */
+.card-color .number-display {
+    font-size: 80px;
+    word-break: break-word;
+    max-width: 100%;
+}
+
 .mode-select {
     margin-bottom: 20px;
 }
@@ -70,7 +77,7 @@ body {
 }
 
 .object {
-    font-size: 40px;
+    font-size: 100px;
 }
 
 .spelling-display {
@@ -106,23 +113,17 @@ button:disabled {
 #prev-btn:disabled,
 #next-btn:disabled,
 #alphabet-prev-btn:disabled,
-#alphabet-next-btn:disabled {
+#alphabet-next-btn:disabled,
+#color-prev-btn:disabled,
+#color-next-btn:disabled {
     background-color: #a9a9a9; /* DarkGray */
 }
 
 #prev-btn:disabled:hover,
 #next-btn:disabled:hover,
 #alphabet-prev-btn:disabled:hover,
-#alphabet-next-btn:disabled:hover {
+#alphabet-next-btn:disabled:hover,
+#color-prev-btn:disabled:hover,
+#color-next-btn:disabled:hover {
     background-color: #a9a9a9;
-}
-
-#prev-btn,
-#alphabet-prev-btn {
-    background-color: #ff7f50; /* Coral */
-}
-
-#prev-btn:hover,
-#alphabet-prev-btn:hover {
-    background-color: #ff9f7a;
 }


### PR DESCRIPTION
## Summary
- Constrain color word width to prevent overflow within the card
- Add tests verifying all ten colors render correctly and match their hex styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c9dfdb308324a4d33a0aad4dc396