### PR TITLE
Fix oversized number icons overflowing card

### DIFF
--- a/style.css
+++ b/style.css
@@ -76,6 +76,10 @@ body {
     margin: 0 auto 20px;
 }
 
+#objects-display .object {
+    font-size: 40px;
+}
+
 .object {
     font-size: 100px;
 }


### PR DESCRIPTION
## Summary
- restrict reduced object icon size to numbers mode so alphabet and colors keep their original scale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899cff1ac60832490f1cc3ec17d0d8f