### PR TITLE
Add shapes, vegetables, and fruits learning modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # improved-spoon
 
-A simple counting app that displays objects and now speaks the current number.
+A simple learning app that displays objects and speaks their names. Learn numbers, the alphabet, colors, shapes, vegetables, and fruits.
 
 ## Testing
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,9 @@
             <option value="numbers">Numbers</option>
             <option value="alphabet">Alphabet</option>
             <option value="colors">Colors</option>
+            <option value="shapes">Shapes</option>
+            <option value="vegetables">Vegetables</option>
+            <option value="fruits">Fruits</option>
         </select>
     </div>
     <div class="card" id="card">
@@ -45,6 +48,39 @@
             <div class="buttons">
                 <button id="color-prev-btn">Previous</button>
                 <button id="color-next-btn">Next</button>
+            </div>
+        </div>
+        <div class="card-face card-shapes">
+            <div id="shape-display" class="number-display">Circle</div>
+            <div id="shape-objects-display" class="objects-display">
+                <div class="dot"></div>
+            </div>
+            <div id="shape-spelling-display" class="spelling-display"></div>
+            <div class="buttons">
+                <button id="shape-prev-btn">Previous</button>
+                <button id="shape-next-btn">Next</button>
+            </div>
+        </div>
+        <div class="card-face card-vegetables">
+            <div id="vegetable-display" class="number-display">Carrot</div>
+            <div id="vegetable-objects-display" class="objects-display">
+                <div class="dot"></div>
+            </div>
+            <div id="vegetable-spelling-display" class="spelling-display"></div>
+            <div class="buttons">
+                <button id="vegetable-prev-btn">Previous</button>
+                <button id="vegetable-next-btn">Next</button>
+            </div>
+        </div>
+        <div class="card-face card-fruits">
+            <div id="fruit-display" class="number-display">Apple</div>
+            <div id="fruit-objects-display" class="objects-display">
+                <div class="dot"></div>
+            </div>
+            <div id="fruit-spelling-display" class="spelling-display"></div>
+            <div class="buttons">
+                <button id="fruit-prev-btn">Previous</button>
+                <button id="fruit-next-btn">Next</button>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const cardFront = document.querySelector('.card-front');
     const cardBack = document.querySelector('.card-back');
     const cardColor = document.querySelector('.card-color');
+    const cardShape = document.querySelector('.card-shapes');
+    const cardVegetable = document.querySelector('.card-vegetables');
+    const cardFruit = document.querySelector('.card-fruits');
 
     const numberElements = {
         display: document.getElementById('number-display'),
@@ -29,15 +32,45 @@ document.addEventListener('DOMContentLoaded', () => {
         next: document.getElementById('color-next-btn')
     };
 
+    const shapeElements = {
+        display: document.getElementById('shape-display'),
+        objects: document.getElementById('shape-objects-display'),
+        spelling: document.getElementById('shape-spelling-display'),
+        prev: document.getElementById('shape-prev-btn'),
+        next: document.getElementById('shape-next-btn')
+    };
+
+    const vegetableElements = {
+        display: document.getElementById('vegetable-display'),
+        objects: document.getElementById('vegetable-objects-display'),
+        spelling: document.getElementById('vegetable-spelling-display'),
+        prev: document.getElementById('vegetable-prev-btn'),
+        next: document.getElementById('vegetable-next-btn')
+    };
+
+    const fruitElements = {
+        display: document.getElementById('fruit-display'),
+        objects: document.getElementById('fruit-objects-display'),
+        spelling: document.getElementById('fruit-spelling-display'),
+        prev: document.getElementById('fruit-prev-btn'),
+        next: document.getElementById('fruit-next-btn')
+    };
+
     const elements = {
         numbers: numberElements,
         alphabet: alphabetElements,
-        colors: colorElements
+        colors: colorElements,
+        shapes: shapeElements,
+        vegetables: vegetableElements,
+        fruits: fruitElements
     };
 
     let currentNumber = 1;
     let currentLetterIndex = 0;
     let currentColorIndex = 0;
+    let currentShapeIndex = 0;
+    let currentVegetableIndex = 0;
+    let currentFruitIndex = 0;
     const minNumber = 1;
     let mode = 'numbers';
 
@@ -93,6 +126,65 @@ document.addEventListener('DOMContentLoaded', () => {
         { name: 'Brown', emoji: '🟤', hex: '#A52A2A' },
         { name: 'Black', emoji: '⚫', hex: '#000000' },
         { name: 'White', emoji: '⚪', hex: '#FFFFFF' }
+    ];
+
+    const shapes = [
+        { name: 'Circle', emoji: '⚪' },
+        { name: 'Square', emoji: '⬜' },
+        { name: 'Triangle', emoji: '🔺' },
+        { name: 'Star', emoji: '⭐️' },
+        { name: 'Heart', emoji: '❤️' },
+        { name: 'Diamond', emoji: '♦️' },
+        { name: 'Pentagon', emoji: '⬠' },
+        { name: 'Hexagon', emoji: '⬢' },
+        { name: 'Octagon', emoji: '🛑' },
+        { name: 'Rectangle', emoji: '▭' }
+    ];
+
+    const vegetables = [
+        { name: 'Carrot', emoji: '🥕' },
+        { name: 'Broccoli', emoji: '🥦' },
+        { name: 'Corn', emoji: '🌽' },
+        { name: 'Tomato', emoji: '🍅' },
+        { name: 'Potato', emoji: '🥔' },
+        { name: 'Eggplant', emoji: '🍆' },
+        { name: 'Cucumber', emoji: '🥒' },
+        { name: 'Garlic', emoji: '🧄' },
+        { name: 'Onion', emoji: '🧅' },
+        { name: 'Peas', emoji: '🫘' },
+        { name: 'Leafy Green', emoji: '🥬' },
+        { name: 'Mushroom', emoji: '🍄' },
+        { name: 'Pepper', emoji: '🫑' },
+        { name: 'Sweet Potato', emoji: '🍠' },
+        { name: 'Avocado', emoji: '🥑' },
+        { name: 'Chili Pepper', emoji: '🌶️' },
+        { name: 'Celery', emoji: '🥬' },
+        { name: 'Beans', emoji: '🫘' },
+        { name: 'Pumpkin', emoji: '🎃' },
+        { name: 'Radish', emoji: '🥕' }
+    ];
+
+    const fruits = [
+        { name: 'Apple', emoji: '🍎' },
+        { name: 'Banana', emoji: '🍌' },
+        { name: 'Grapes', emoji: '🍇' },
+        { name: 'Orange', emoji: '🍊' },
+        { name: 'Strawberry', emoji: '🍓' },
+        { name: 'Pineapple', emoji: '🍍' },
+        { name: 'Mango', emoji: '🥭' },
+        { name: 'Watermelon', emoji: '🍉' },
+        { name: 'Pear', emoji: '🍐' },
+        { name: 'Peach', emoji: '🍑' },
+        { name: 'Cherries', emoji: '🍒' },
+        { name: 'Lemon', emoji: '🍋' },
+        { name: 'Kiwi', emoji: '🥝' },
+        { name: 'Blueberries', emoji: '🫐' },
+        { name: 'Coconut', emoji: '🥥' },
+        { name: 'Melon', emoji: '🍈' },
+        { name: 'Green Apple', emoji: '🍏' },
+        { name: 'Grapefruit', emoji: '🍊' },
+        { name: 'Plum', emoji: '🍑' },
+        { name: 'Tangerine', emoji: '🍊' }
     ];
 
     let speakTimeout;
@@ -156,7 +248,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             speak(letter.toLowerCase());
             speakTimeout = setTimeout(() => speak(word), 1000);
-        } else {
+        } else if (mode === 'colors') {
             currentColorIndex = Math.max(0, Math.min(currentColorIndex, colors.length - 1));
             const { name, emoji, hex } = colors[currentColorIndex];
 
@@ -182,6 +274,54 @@ document.addEventListener('DOMContentLoaded', () => {
             applyBtnStyle(el.next);
 
             speak(name);
+        } else if (mode === 'shapes') {
+            currentShapeIndex = Math.max(0, Math.min(currentShapeIndex, shapes.length - 1));
+            const { name, emoji } = shapes[currentShapeIndex];
+
+            el.display.textContent = name;
+            el.objects.innerHTML = '';
+            const object = document.createElement('div');
+            object.classList.add('object');
+            object.textContent = emoji;
+            el.objects.appendChild(object);
+
+            el.spelling.textContent = '';
+            el.prev.disabled = currentShapeIndex === 0;
+            el.next.disabled = currentShapeIndex === shapes.length - 1;
+
+            speak(name);
+        } else if (mode === 'vegetables') {
+            currentVegetableIndex = Math.max(0, Math.min(currentVegetableIndex, vegetables.length - 1));
+            const { name, emoji } = vegetables[currentVegetableIndex];
+
+            el.display.textContent = name;
+            el.objects.innerHTML = '';
+            const object = document.createElement('div');
+            object.classList.add('object');
+            object.textContent = emoji;
+            el.objects.appendChild(object);
+
+            el.spelling.textContent = '';
+            el.prev.disabled = currentVegetableIndex === 0;
+            el.next.disabled = currentVegetableIndex === vegetables.length - 1;
+
+            speak(name);
+        } else if (mode === 'fruits') {
+            currentFruitIndex = Math.max(0, Math.min(currentFruitIndex, fruits.length - 1));
+            const { name, emoji } = fruits[currentFruitIndex];
+
+            el.display.textContent = name;
+            el.objects.innerHTML = '';
+            const object = document.createElement('div');
+            object.classList.add('object');
+            object.textContent = emoji;
+            el.objects.appendChild(object);
+
+            el.spelling.textContent = '';
+            el.prev.disabled = currentFruitIndex === 0;
+            el.next.disabled = currentFruitIndex === fruits.length - 1;
+
+            speak(name);
         }
 
     }
@@ -196,6 +336,15 @@ document.addEventListener('DOMContentLoaded', () => {
         } else if (mode === 'colors' && currentColorIndex < colors.length - 1) {
             currentColorIndex++;
             updateDisplay();
+        } else if (mode === 'shapes' && currentShapeIndex < shapes.length - 1) {
+            currentShapeIndex++;
+            updateDisplay();
+        } else if (mode === 'vegetables' && currentVegetableIndex < vegetables.length - 1) {
+            currentVegetableIndex++;
+            updateDisplay();
+        } else if (mode === 'fruits' && currentFruitIndex < fruits.length - 1) {
+            currentFruitIndex++;
+            updateDisplay();
         }
     }
 
@@ -209,20 +358,38 @@ document.addEventListener('DOMContentLoaded', () => {
         } else if (mode === 'colors' && currentColorIndex > 0) {
             currentColorIndex--;
             updateDisplay();
+        } else if (mode === 'shapes' && currentShapeIndex > 0) {
+            currentShapeIndex--;
+            updateDisplay();
+        } else if (mode === 'vegetables' && currentVegetableIndex > 0) {
+            currentVegetableIndex--;
+            updateDisplay();
+        } else if (mode === 'fruits' && currentFruitIndex > 0) {
+            currentFruitIndex--;
+            updateDisplay();
         }
     }
 
     numberElements.next.addEventListener('click', handleNext);
     alphabetElements.next.addEventListener('click', handleNext);
     colorElements.next.addEventListener('click', handleNext);
+    shapeElements.next.addEventListener('click', handleNext);
+    vegetableElements.next.addEventListener('click', handleNext);
+    fruitElements.next.addEventListener('click', handleNext);
     numberElements.prev.addEventListener('click', handlePrev);
     alphabetElements.prev.addEventListener('click', handlePrev);
     colorElements.prev.addEventListener('click', handlePrev);
+    shapeElements.prev.addEventListener('click', handlePrev);
+    vegetableElements.prev.addEventListener('click', handlePrev);
+    fruitElements.prev.addEventListener('click', handlePrev);
 
     function showFace(currentMode) {
         cardFront.style.display = currentMode === 'numbers' ? 'flex' : 'none';
         cardBack.style.display = currentMode === 'alphabet' ? 'flex' : 'none';
         cardColor.style.display = currentMode === 'colors' ? 'flex' : 'none';
+        cardShape.style.display = currentMode === 'shapes' ? 'flex' : 'none';
+        cardVegetable.style.display = currentMode === 'vegetables' ? 'flex' : 'none';
+        cardFruit.style.display = currentMode === 'fruits' ? 'flex' : 'none';
     }
 
     modeSelect.addEventListener('change', () => {
@@ -235,10 +402,22 @@ document.addEventListener('DOMContentLoaded', () => {
             currentLetterIndex = 0;
             card.classList.add('flipped');
             showFace('alphabet');
-        } else {
+        } else if (mode === 'colors') {
             currentColorIndex = 0;
             card.classList.remove('flipped');
             showFace('colors');
+        } else if (mode === 'shapes') {
+            currentShapeIndex = 0;
+            card.classList.remove('flipped');
+            showFace('shapes');
+        } else if (mode === 'vegetables') {
+            currentVegetableIndex = 0;
+            card.classList.remove('flipped');
+            showFace('vegetables');
+        } else {
+            currentFruitIndex = 0;
+            card.classList.remove('flipped');
+            showFace('fruits');
         }
         updateDisplay();
     });
@@ -274,6 +453,24 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         set currentColorIndex(value) {
             currentColorIndex = value;
+        },
+        get currentShapeIndex() {
+            return currentShapeIndex;
+        },
+        set currentShapeIndex(value) {
+            currentShapeIndex = value;
+        },
+        get currentVegetableIndex() {
+            return currentVegetableIndex;
+        },
+        set currentVegetableIndex(value) {
+            currentVegetableIndex = value;
+        },
+        get currentFruitIndex() {
+            return currentFruitIndex;
+        },
+        set currentFruitIndex(value) {
+            currentFruitIndex = value;
         },
         get mode() {
             return mode;

--- a/script.test.js
+++ b/script.test.js
@@ -45,12 +45,30 @@ describe('updateDisplay', () => {
       'color-prev-btn': createMockElement(),
       'color-next-btn': createMockElement(),
       'color-spelling-display': createMockElement(),
+      'shape-display': createMockElement(),
+      'shape-objects-display': createMockElement(),
+      'shape-prev-btn': createMockElement(),
+      'shape-next-btn': createMockElement(),
+      'shape-spelling-display': createMockElement(),
+      'vegetable-display': createMockElement(),
+      'vegetable-objects-display': createMockElement(),
+      'vegetable-prev-btn': createMockElement(),
+      'vegetable-next-btn': createMockElement(),
+      'vegetable-spelling-display': createMockElement(),
+      'fruit-display': createMockElement(),
+      'fruit-objects-display': createMockElement(),
+      'fruit-prev-btn': createMockElement(),
+      'fruit-next-btn': createMockElement(),
+      'fruit-spelling-display': createMockElement(),
     };
 
     const selectors = {
       '.card-front': createMockElement(),
       '.card-back': createMockElement(),
       '.card-color': createMockElement(),
+      '.card-shapes': createMockElement(),
+      '.card-vegetables': createMockElement(),
+      '.card-fruits': createMockElement(),
     };
 
     const document = {
@@ -215,6 +233,48 @@ describe('updateDisplay', () => {
     }
     expect(app.numberDisplay.textContent).toBe('A');
     expect(app.prevBtn.disabled).toBe(true);
+  });
+
+  test('shape mode displays shapes and disables navigation at boundaries', () => {
+    const app = setup();
+    app.modeSelect.value = 'shapes';
+    app.modeSelect.dispatchEvent(new Event('change'));
+    expect(app.numberDisplay.textContent).toBe('Circle');
+    expect(app.objectsDisplay.children[0].textContent).toBe('⚪');
+    expect(app.prevBtn.disabled).toBe(true);
+    let count = 1;
+    while (!app.nextBtn.disabled) {
+      app.nextBtn.click();
+      count++;
+    }
+    expect(count).toBe(10);
+    expect(app.numberDisplay.textContent).toBe('Rectangle');
+  });
+
+  test('vegetables and fruits modes have correct counts', () => {
+    const app = setup();
+
+    app.modeSelect.value = 'vegetables';
+    app.modeSelect.dispatchEvent(new Event('change'));
+    expect(app.numberDisplay.textContent).toBe('Carrot');
+    let vegCount = 1;
+    while (!app.nextBtn.disabled) {
+      app.nextBtn.click();
+      vegCount++;
+    }
+    expect(vegCount).toBe(20);
+    expect(app.numberDisplay.textContent).toBe('Radish');
+
+    app.modeSelect.value = 'fruits';
+    app.modeSelect.dispatchEvent(new Event('change'));
+    expect(app.numberDisplay.textContent).toBe('Apple');
+    let fruitCount = 1;
+    while (!app.nextBtn.disabled) {
+      app.nextBtn.click();
+      fruitCount++;
+    }
+    expect(fruitCount).toBe(20);
+    expect(app.numberDisplay.textContent).toBe('Tangerine');
   });
 
   test('arrow keys navigate numbers', () => {


### PR DESCRIPTION
## Summary
- extend learning app with new modes for shapes, vegetables, and fruits
- add corresponding content and navigation support
- cover new modes with tests and update documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dc6d21a688324859afd2c1d5ef5ab